### PR TITLE
[*] WS : Use child implementation of protected functions.

### DIFF
--- a/PSWebServiceLibrary.php
+++ b/PSWebServiceLibrary.php
@@ -215,10 +215,10 @@ class PrestaShopWebservice
 		}
 		else
 			throw new PrestaShopWebserviceException('Bad parameters given');
-		$request = self::executeRequest($url, array(CURLOPT_CUSTOMREQUEST => 'POST', CURLOPT_POSTFIELDS => 'xml='.urlencode($xml)));
+		$request = $this->executeRequest($url, array(CURLOPT_CUSTOMREQUEST => 'POST', CURLOPT_POSTFIELDS => 'xml='.urlencode($xml)));
 
-		self::checkStatusCode($request['status_code']);
-		return self::parseXML($request['response']);
+		$this->checkStatusCode($request['status_code']);
+		return $this->parseXML($request['response']);
 	}
 
 	/**
@@ -271,10 +271,10 @@ class PrestaShopWebservice
 		else
 			throw new PrestaShopWebserviceException('Bad parameters given');
 		
-		$request = self::executeRequest($url, array(CURLOPT_CUSTOMREQUEST => 'GET'));
+		$request = $this->executeRequest($url, array(CURLOPT_CUSTOMREQUEST => 'GET'));
 		
-		self::checkStatusCode($request['status_code']);// check the response validity
-		return self::parseXML($request['response']);
+		$this->checkStatusCode($request['status_code']);// check the response validity
+		return $this->parseXML($request['response']);
 	}
 
 	/**
@@ -304,8 +304,8 @@ class PrestaShopWebservice
 		}
 		else
 			throw new PrestaShopWebserviceException('Bad parameters given');
-		$request = self::executeRequest($url, array(CURLOPT_CUSTOMREQUEST => 'HEAD', CURLOPT_NOBODY => true));
-		self::checkStatusCode($request['status_code']);// check the response validity
+		$request = $this->executeRequest($url, array(CURLOPT_CUSTOMREQUEST => 'HEAD', CURLOPT_NOBODY => true));
+		$this->checkStatusCode($request['status_code']);// check the response validity
 		return $request['header'];
 	}
 	/**
@@ -330,9 +330,9 @@ class PrestaShopWebservice
 		else
 			throw new PrestaShopWebserviceException('Bad parameters given');
 		
-		$request = self::executeRequest($url,  array(CURLOPT_CUSTOMREQUEST => 'PUT', CURLOPT_POSTFIELDS => $xml));
-		self::checkStatusCode($request['status_code']);// check the response validity
-		return self::parseXML($request['response']);
+		$request = $this->executeRequest($url,  array(CURLOPT_CUSTOMREQUEST => 'PUT', CURLOPT_POSTFIELDS => $xml));
+		$this->checkStatusCode($request['status_code']);// check the response validity
+		return $this->parseXML($request['response']);
 	}
 
 	/**
@@ -367,8 +367,8 @@ class PrestaShopWebservice
 				$url = $this->url.'/api/'.$options['resource'].'/?id=['.implode(',', $options['id']).']';
 			else
 				$url = $this->url.'/api/'.$options['resource'].'/'.$options['id'];
-		$request = self::executeRequest($url, array(CURLOPT_CUSTOMREQUEST => 'DELETE'));
-		self::checkStatusCode($request['status_code']);// check the response validity
+		$request = $this->executeRequest($url, array(CURLOPT_CUSTOMREQUEST => 'DELETE'));
+		$this->checkStatusCode($request['status_code']);// check the response validity
 		return true;
 	}
 	


### PR DESCRIPTION
Effectively overriding protected functions `executeRequest`,
`checkStatusCode`, `parseXML` requires referencing them with either
`static::` or `$this->`. PrestaShop maintains PHP 5.2 compatibility, but
fortunately the methods aren't declared to be static. `$this->` seems
workable.
